### PR TITLE
Refactor clear constraint window later

### DIFF
--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -835,12 +835,10 @@ function timetableGUI.makeArrDepWindow(lineID, stationID)
     addButton:onClick(function()
         timetable.addCondition(lineID,stationID, {type = "ArrDep", ArrDep = {{0,0,0,0}}})
         timetableChanged = true
-        clearConstraintWindowLaterHACK = function()
+
             timetableGUI.initStationTable()
             timetableGUI.fillStationTable(UIState.currentlySelectedLineTableIndex, false)
-            timetableGUI.clearConstraintWindow()
-            timetableGUI.makeArrDepWindow(lineID, stationID)
-        end
+            timetableGUI.makeArrDepConstraintsTable(lineID, stationID)
     end)
 
     -- setup deleteButton button

--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -975,12 +975,11 @@ function timetableGUI.makeArrDepConstraintsTable(lineID, stationID)
         insertButton:onClick(function()
             timetable.insertArrDepCondition(lineID, stationID, k, {0,0,0,0})
             timetableChanged = true
-            clearConstraintWindowLaterHACK = function()
-                timetableGUI.initStationTable()
-                timetableGUI.fillStationTable(UIState.currentlySelectedLineTableIndex, false)
-                timetableGUI.clearConstraintWindow()
-                timetableGUI.makeArrDepWindow(lineID, stationID)
-            end
+            timetableGUI.initStationTable()
+            timetableGUI.fillStationTable(UIState.currentlySelectedLineTableIndex, false)
+            menu.constraintTable:invokeLater( function ()
+                timetableGUI.makeArrDepConstraintsTable(lineID, stationID)
+            end)
         end)
 
         local linetable2 = api.gui.comp.Table.new(5, 'NONE')

--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -916,12 +916,12 @@ function timetableGUI.makeArrDepConstraintsTable(lineID, stationID)
             timetableGUI.popUpYesNo("Delete?", function()
                 timetable.removeCondition(lineID, stationID, "ArrDep", k)
                 timetableChanged = true
-                clearConstraintWindowLaterHACK = function()
-                    timetableGUI.initStationTable()
-                    timetableGUI.fillStationTable(UIState.currentlySelectedLineTableIndex, false)
-                    timetableGUI.clearConstraintWindow()
-                    timetableGUI.makeArrDepWindow(lineID, stationID)
-                end
+                timetableGUI.initStationTable()
+                timetableGUI.fillStationTable(UIState.currentlySelectedLineTableIndex, false)
+                menu.constraintTable:invokeLater( function ()
+                    timetableGUI.makeArrDepConstraintsTable(lineID, stationID)
+                end)
+
                 deleteButton:setEnabled(true)
             end, function()
                 deleteButton:setEnabled(true)
@@ -1009,6 +1009,8 @@ function timetableGUI.makeDebounceWindow(lineID, stationID, debounceType)
     if condition == -1 then return end
     local autoDebounceMin = nil
     local autoDebounceSec = nil
+
+    menu.constraintContentTable:deleteAll()
 
     local updateAutoDebounce = function()
         if debounceType == "auto_debounce" then

--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -591,13 +591,14 @@ function timetableGUI.fillStationTable(index, bool)
             timetableGUI.initConstraintTable()
             timetableGUI.fillConstraintTable(tableIndex,lineID)
         end
-
     end)
 
     -- keep track of currently selected station and resets if nessesarry
     if UIState.currentlySelectedStationIndex then
         if menu.stationTable:getNumRows() > UIState.currentlySelectedStationIndex and not(menu.stationTable:getNumRows() == 0) then
             menu.stationTable:select(UIState.currentlySelectedStationIndex, bool)
+        else
+            timetableGUI.initConstraintTable()
         end
     end
     menu.stationScrollArea:invokeLater(function () 
@@ -735,6 +736,7 @@ function timetableGUI.fillConstraintTable(index,lineID)
         end
 
         timetableGUI.clearConstraintWindow()
+        menu.constraintContentTable:deleteAll()
         if i == 1 then
             timetableGUI.makeArrDepWindow(lineID, index)
         elseif i == 2 then
@@ -1007,8 +1009,6 @@ function timetableGUI.makeDebounceWindow(lineID, stationID, debounceType)
     if condition == -1 then return end
     local autoDebounceMin = nil
     local autoDebounceSec = nil
-
-    menu.constraintContentTable:deleteAll()
 
     local updateAutoDebounce = function()
         if debounceType == "auto_debounce" then

--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -19,7 +19,6 @@ local co = nil
 local state = nil
 
 local timetableChanged = false
-local clearConstraintWindowLaterHACK = nil
 
 local stationTableScrollOffset
 local lineTableScrollOffset
@@ -1231,10 +1230,6 @@ function data()
             if timetableChanged then
                 game.interface.sendScriptEvent("timetableUpdate", "", timetable.getTimetableObject())
                 timetableChanged = false
-            end
-            if clearConstraintWindowLaterHACK then
-                clearConstraintWindowLaterHACK()
-                clearConstraintWindowLaterHACK = nil
             end
 
             if not clockstate then

--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -850,12 +850,10 @@ function timetableGUI.makeArrDepWindow(lineID, stationID)
         timetableGUI.popUpYesNo("Delete All?", function()
             timetable.removeAllConditions(lineID, stationID, "ArrDep")
             timetableChanged = true
-            clearConstraintWindowLaterHACK = function()
-                timetableGUI.initStationTable()
-                timetableGUI.fillStationTable(UIState.currentlySelectedLineTableIndex, false)
-                timetableGUI.clearConstraintWindow()
-                timetableGUI.makeArrDepWindow(lineID, stationID)
-            end
+            timetableGUI.initStationTable()
+            timetableGUI.fillStationTable(UIState.currentlySelectedLineTableIndex, false)
+            timetableGUI.makeArrDepConstraintsTable(lineID, stationID)
+            
             deleteButton:setEnabled(true)
         end, function()
             deleteButton:setEnabled(true)


### PR DESCRIPTION
- Fixes: #40 
---
- Removed `clearConstraintWindowLaterHACK`
- Split constraints into header and content tables. Content is used only for ArrDep mode to contain just the timetable slots.