### PR TITLE
Fix and Refactor: Vehicle get reassigned it's previous slot

### DIFF
--- a/tests/timetable_tests.lua
+++ b/tests/timetable_tests.lua
@@ -147,6 +147,7 @@ timetableTests[#timetableTests + 1] = function()
     local constraints = {{00,00,40,00}}
     timetable.addCondition(1, 1, {type = "ArrDep", ArrDep = constraints}) 
 
+    local vehicles = {1}
     local vehiclesWaiting = {}
 
     local time = (20*60) + 0 -- 20:00
@@ -154,62 +155,62 @@ timetableTests[#timetableTests + 1] = function()
         return time
     end
     local arrivalTime = time
-    local x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    local x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = (30*60) + 0 -- 30:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = (40*60) + 0 -- 40:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = (50*60) + 0 -- 50:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 3600 + (00*60) + 0 -- 00:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 3600 + (10*60) + 0 -- 10:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 3600 + (20*60) + 0 -- 20:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
 
 
     time = 3600 + (50*60) + 0 -- 50:00
     arrivalTime = time
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = 7200 + (0*60) + 0 -- 00:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = 7200 + (10*60) + 0 -- 10:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = 7200 + (20*60) + 0 -- 20:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = 7200 + (30*60) + 0 -- 30:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = 7200 + (40*60) + 0 -- 40:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 7200 + (50*60) + 0 -- 50:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 end
 
@@ -219,6 +220,7 @@ timetableTests[#timetableTests + 1] = function()
     local constraints = {{00,00,20,00}}
     timetable.addCondition(1, 1, {type = "ArrDep", ArrDep = constraints})
 
+    local vehicles = {1}
     local vehiclesWaiting = {}
 
     local time = (40*60) + 0 -- 40:00
@@ -226,35 +228,35 @@ timetableTests[#timetableTests + 1] = function()
         return time
     end
     local arrivalTime = time
-    local x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    local x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = (50*60) -- 50:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = 3600 + (00*60) -- 00:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = 3600 + (10*60) -- 10:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = 3600 + (20*60) -- 20:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 3600 + (30*60) -- 30:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 3600 + (40*60) -- 40:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 3600 + (50*60) -- 50:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 end
 
@@ -264,6 +266,7 @@ timetableTests[#timetableTests + 1] = function()
     local constraints = {{27,00,28,00}}
     timetable.addCondition(1, 1, {type = "ArrDep", ArrDep = constraints})
 
+    local vehicles = {1}
     local vehiclesWaiting = {}
 
     local time = (26*60) + 0 -- 26:00
@@ -271,56 +274,56 @@ timetableTests[#timetableTests + 1] = function()
         return time
     end
     local arrivalTime = time
-    local x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    local x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = (27*60) -- 27:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = (28*60) -- 28:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = (29*60) -- 29:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
 
     
     time = 3600 + (27*60) -- 27:00
     arrivalTime = time
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "should be before departure")
 
     time = 3600 + (28*60) -- 28:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 3600 + (29*60) -- 29:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
 
 
     time = 7200 + (28*60) -- 28:00
     arrivalTime = time
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 7200 + (29*60) -- 29:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
 
 
     time = 10800 + (29*60) -- 29:00
     arrivalTime = time
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 
     time = 10800 + (30*60) -- 30:00
-    x = timetable.readyToDepartArrDep(arrivalTime, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "should be after departure")
 end
 
@@ -333,6 +336,7 @@ timetableTests[#timetableTests + 1] = function()
     local constraints = {{55, 0, 58, 0}, {57, 0, 0, 0}, {59, 0, 2, 0}}
     timetable.addCondition(1, 1, {type = "ArrDep", ArrDep = constraints})
 
+    local vehicles = {1, 2}
     local vehiclesWaiting = {}
 
     local time = (57*60) + 1 -- 57:01
@@ -340,32 +344,32 @@ timetableTests[#timetableTests + 1] = function()
         return time
     end
     local arrivalTime1 = time
-    local x = timetable.readyToDepartArrDep(arrivalTime1, time, 1, 1, 1, vehiclesWaiting)
+    local x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (59*60) + 11 -- 59:11
     local arrivalTime2 = time
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (60*60) + 0 -- 00:00
-    x = timetable.readyToDepartArrDep(arrivalTime1, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "Shouldn't wait for train")
 
     time = (60*60) + 1 -- 00:01
-    x = timetable.readyToDepartArrDep(arrivalTime1, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "Shouldn't wait for train")
 
     time = (60*60) + 0 -- 00:00
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (62*60) + 0 -- 02:00
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "Shouldn't wait for train")
 
     time = (62*60) + 1 -- 02:01
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "Shouldn't wait for train")
 end
 
@@ -376,6 +380,7 @@ timetableTests[#timetableTests + 1] = function()
     local constraints = {{5, 0, 7, 0}, {15, 0, 17, 0}, {25, 0, 27, 0}, {35, 0, 37, 0}, {45, 0, 47, 0}, {55, 0, 57, 0}}
     timetable.addCondition(1, 1, {type = "ArrDep", ArrDep = constraints})
 
+    local vehicles = {1, 2}
     local vehiclesWaiting = {}
 
     local time = (5*60) + 1 -- 05:01
@@ -383,26 +388,26 @@ timetableTests[#timetableTests + 1] = function()
         return time
     end
     local arrivalTime1 = time
-    local x = timetable.readyToDepartArrDep(arrivalTime1, time, 1, 1, 1, vehiclesWaiting)
+    local x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (7*60) + 0 -- 07:00
-    x = timetable.readyToDepartArrDep(arrivalTime1, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "Shouldn't wait for train")
 
     time = (8*60) + 11 -- 08:11
     local arrivalTime2 = time
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (15*60) + 11 -- 15:11
     local arrivalTime2 = time
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (17*60) -- 17:00
     local arrivalTime2 = time
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "Shouldn't wait for train")
 end
 
@@ -413,6 +418,7 @@ timetableTests[#timetableTests + 1] = function()
     local constraints = {{5, 0, 30, 0}, {35, 0, 0, 0}}
     timetable.addCondition(1, 1, {type = "ArrDep", ArrDep = constraints})
 
+    local vehicles = {1, 2}
     local vehiclesWaiting = {}
 
     local time = (05*60) -- 05:00
@@ -420,28 +426,28 @@ timetableTests[#timetableTests + 1] = function()
         return time
     end
     local arrivalTime1 = time
-    local x = timetable.readyToDepartArrDep(arrivalTime1, time, 1, 1, 1, vehiclesWaiting)
+    local x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (29*60) + 59 -- 29:59
-    x = timetable.readyToDepartArrDep(arrivalTime1, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (30*60) -- 30:00
-    x = timetable.readyToDepartArrDep(arrivalTime1, time, 1, 1, 1, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "Shouldn't wait for train")
 
     local time = (35*60) + 1 -- 35:01
     local arrivalTime2 = time
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (59*60) -- 59:00
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(not x, "Should wait for train")
 
     time = (60*60) + 0 -- 00:00
-    x = timetable.readyToDepartArrDep(arrivalTime2, time, 1, 1, 2, vehiclesWaiting)
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
     assert(x, "Shouldn't wait for train")
 end
 
@@ -473,6 +479,92 @@ timetableTests[#timetableTests + 1] = function()
     -- Vehicle 2 arrives before vehicle 1 departs, so vehicle 1 doesn't get removed from vehiclesWaiting on 2s arrival.
     -- Vehicle 3 arrives at 09:00, but shouldn't take this slot as vehicle 2 is still waiting with it allocated.
     -- Instead vehicle 1 should get removed from vehiclesWaiting, and vehicle 3 can pick this timetable slot up.
+end
+
+-- Tests for issue #62 with one vehicle
+timetableTests[#timetableTests + 1] = function()
+    testsHelper.setUpMock()
+    timetable.setTimetableObject({})
+    local constraints = {{0, 0, 2, 0}, {4, 0, 6, 0}, {8, 0, 10, 0}}
+    timetable.addCondition(1, 1, {type = "ArrDep", ArrDep = constraints})
+
+    local vehicles = {1}
+    local vehiclesWaiting = {}
+
+    local time = (00*60) -- 00:00
+    mockTimetableHelper.getTime = function()
+        return time
+    end
+    local arrivalTime = time
+    local x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(not x, "Should wait for train")
+
+    time = (02*60) -- 02:00
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(x, "Shouldn't wait for train")
+
+    time = (04*60) -- 04:00
+    arrivalTime = time
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(not x, "Should wait for train")
+
+    time = (06*60) -- 06:00
+    x = timetable.readyToDepartArrDep(1, arrivalTime, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(x, "Shouldn't wait for train")
+end
+
+-- Tests for issue #62 with two vehicles
+timetableTests[#timetableTests+1] = function ()
+    testsHelper.setUpMock()
+    timetable.setTimetableObject({})
+    local constraints = {{ 24, 0, 25, 0, }, { 26, 0, 27, 0, }, { 28, 0, 29, 0, }, { 30, 0, 31, 0, }}
+    timetable.addCondition(1, 1, {type = "ArrDep", ArrDep = constraints})
+
+    local arrivalTime1 = (23*60) + 30 -- 23:30
+    local arrivalTime2 = (24*60) -- 24:00
+
+    local vehicles = {1, 2}
+    local vehiclesWaiting = {
+        [1] = {
+            arrivalTime = arrivalTime1,
+            departureTime = 1500,
+            slot = { 24, 0, 25, 0, },
+        },
+        [2] = {
+            arrivalTime = arrivalTime2,
+            departureTime = 1620,
+            slot = { 26, 0, 27, 0, },
+        },
+    }
+
+    local time = (24*60) -- 24:00
+    local x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(not x, "Should wait for train")
+
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(not x, "Should wait for train")
+
+    time = (25*60) -- 25:00
+    x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(x, "Shouldn't wait for train")
+
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(not x, "Should wait for train")
+
+    time = (26*60) -- 26:00
+    arrivalTime1 = time
+    x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(not x, "Should wait for train")
+
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(not x, "Should wait for train")
+
+    time = (27*60) -- 27:00
+    x = timetable.readyToDepartArrDep(1, arrivalTime1, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(not x, "Should wait for train")
+
+    x = timetable.readyToDepartArrDep(2, arrivalTime2, vehicles, time, 1, 1, vehiclesWaiting)
+    assert(x, "Shouldn't wait for train")
 end
 
 return {


### PR DESCRIPTION
- Fixes: #62 

- Added `arrivalTime` to `vehiclesWaiting` table items
- Compares the `doorTime` (arrivalTime) to the `vehiclesWaiting[vehicle].arrivalTime` to determine if the slot is old.
Old timetable slots are removed when identified.
- `readyToDepartArrDep` and `readyToDepartDebounce` parameter order changed to be more consistent.
- Some documentation added to `readyToDepartArrDep`