### PR TITLE
Bugs/unbunch multiple platforms

### DIFF
--- a/res/scripts/celmi/timetables/timetable.lua
+++ b/res/scripts/celmi/timetables/timetable.lua
@@ -497,9 +497,9 @@ function timetable.readyToDepartDebounce(vehicle, arrivalTime, vehicles, time, l
         elseif timetable.anotherVehicleArrivedEarlier(vehicle, arrivalTime, line, stop) then
             return false -- Unknown depart time
         elseif debounceIsManual then
-            departureTime = timetable.manualDebounceDepartureTime(arrivalTime, vehicles, time, line, stop)
+            departureTime = timetable.manualDebounceDepartureTime(arrivalTime, vehicles, time, line, stop, vehiclesWaiting)
         else
-            departureTime = timetable.autoDebounceDepartureTime(arrivalTime, vehicles, time, line, stop)
+            departureTime = timetable.autoDebounceDepartureTime(arrivalTime, vehicles, time, line, stop, vehiclesWaiting)
         end
         vehiclesWaiting[vehicle] = { departureTime = departureTime }
     end
@@ -512,8 +512,8 @@ function timetable.readyToDepartDebounce(vehicle, arrivalTime, vehicles, time, l
     return false
 end
 
-function timetable.manualDebounceDepartureTime(arrivalTime, vehicles, time, line, stop)
-    local previousDepartureTime = timetableHelper.getPreviousDepartureTime(stop, vehicles)
+function timetable.manualDebounceDepartureTime(arrivalTime, vehicles, time, line, stop, vehiclesWaiting)
+    local previousDepartureTime = timetableHelper.getPreviousDepartureTime(stop, vehicles, vehiclesWaiting)
     local condition = timetable.getConditions(line, stop, "debounce")
     if condition == -1 then condition = {0, 0} end
     if not condition[1] then condition[1] = 0 end
@@ -525,8 +525,8 @@ function timetable.manualDebounceDepartureTime(arrivalTime, vehicles, time, line
     return timetable.getDepartureTime(line, stop, arrivalTime, waitTime)
 end
 
-function timetable.autoDebounceDepartureTime(arrivalTime, vehicles, time, line, stop)
-    local previousDepartureTime = timetableHelper.getPreviousDepartureTime(stop, vehicles)
+function timetable.autoDebounceDepartureTime(arrivalTime, vehicles, time, line, stop, vehiclesWaiting)
+    local previousDepartureTime = timetableHelper.getPreviousDepartureTime(stop, vehicles, vehiclesWaiting)
     local frequency = timetableObject[line].frequency
     if not frequency then return end
 

--- a/res/scripts/celmi/timetables/timetable_helper.lua
+++ b/res/scripts/celmi/timetables/timetable_helper.lua
@@ -148,7 +148,7 @@ end
 
 ---@param vehicle number | string
 -- returns departure time of previous vehicle
-function timetableHelper.getPreviousDepartureTime(stop, vehicles)
+function timetableHelper.getPreviousDepartureTime(stop, vehicles, vehiclesWaiting)
     if type(stop) == "string" then stop = tonumber(stop) end
     if not(type(stop) == "number") then print("Expected String or Number") return false end
 
@@ -156,10 +156,14 @@ function timetableHelper.getPreviousDepartureTime(stop, vehicles)
     for _,v in pairs(vehicles) do
         -- append to a list using a[#a + 1] = new_item
         local lineVehicle = api.engine.getComponent(v, api.type.ComponentType.TRANSPORT_VEHICLE)
-        departureTimes[#departureTimes + 1] = lineVehicle.lineStopDepartures[stop]
+        departureTimes[#departureTimes + 1] = lineVehicle.lineStopDepartures[stop]/1000
     end
 
-    return (timetableHelper.maximumArray(departureTimes))/1000
+    for _, vehicleWaiting in pairs(vehiclesWaiting) do
+        departureTimes[#departureTimes + 1] = vehicleWaiting.departureTime
+    end
+
+    return (timetableHelper.maximumArray(departureTimes))
 end
 
 ---@param vehicle number | string


### PR DESCRIPTION
- Vehicles would depart simultaneously when using multiple platforms and Unbunch "mode"
- Now it looks for the assigned departure times of the other vehicles first and the previous departure times, and adds the unbunch time onto the latest of those. This prevent vehicles using Unbunch from departing simultaneously.